### PR TITLE
API Fixes

### DIFF
--- a/include/ChromaController.hpp
+++ b/include/ChromaController.hpp
@@ -21,6 +21,7 @@ namespace Chroma {
     private:
         static bool ChromaLegacy;
         static bool ChromaMap;
+        static std::unordered_set<std::string> ModsForcingDoHooks;
 
     public:
         static bool TutorialMode;
@@ -32,7 +33,7 @@ namespace Chroma {
 
         // Return true if Chroma is required/suggested in a map
         static bool ChromaRequired() {
-            return !TutorialMode && ChromaMap;
+            return (!TutorialMode && ChromaMap) || ModsForcingDoHooks.size() > 0;
         }
 
         static void setChromaRequired(bool chromaMap);
@@ -42,6 +43,8 @@ namespace Chroma {
             return getChromaConfig().customColorEventsEnabled.GetValue() && (ChromaRequired());
         }
 
+        static void AddForceDoHooks(ModInfo& modInfo);
+        static void RemoveForceDoHooks(ModInfo& modInfo);
 
         // Quest internal stuff
         static void SetChromaLegacy(bool v);

--- a/shared/CoreAPI.hpp
+++ b/shared/CoreAPI.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "modloader/shared/modloader.hpp"
+#include "conditional-dependencies/shared/main.hpp"
+#include "utils.hpp"
+
+namespace Chroma {
+    class CoreAPI {
+    public:
+        // Adds a mod that will force Chroma to enable its hooks (for colorizing), when not in a Chroma map.
+        static void addForceEnableChromaHooks(ModInfo& modInfo) {
+            static auto function = CondDeps::Find<void, ModInfo&>(CHROMA_ID, "addForceEnableChromaHooks");
+
+            if(function) {
+                function.value()(modInfo);
+            }
+        }
+
+        // Removes a mod so that it will no longer force Chroma to enable its hooks (for colorizing), when not in a Chroma map.
+        static void removeForceEnableChromaHooks(ModInfo& modInfo) {
+            static auto function = CondDeps::Find<void, ModInfo&>(CHROMA_ID, "removeForceEnableChromaHooks");
+
+            if(function) {
+                function.value()(modInfo);
+            }
+        }       
+    };
+}

--- a/shared/NoteAPI.hpp
+++ b/shared/NoteAPI.hpp
@@ -71,8 +71,8 @@ namespace Chroma {
         }
 
         /// Sets the note color if the method was found.
-        static void setNoteColorSafe(GlobalNamespace::NoteController* nc, std::optional<Sombrero::FastColor> color0) noexcept {
-            static auto function = CondDeps::Find<void, GlobalNamespace::NoteController*, std::optional<Sombrero::FastColor>>(CHROMA_ID, "setNoteColorSafe");
+        static void setNoteColorSafe(GlobalNamespace::NoteControllerBase* nc, std::optional<Sombrero::FastColor> color0) noexcept {
+            static auto function = CondDeps::Find<void, GlobalNamespace::NoteControllerBase*, std::optional<Sombrero::FastColor>>(CHROMA_ID, "setNoteColorSafe");
 
             if (function) {
                 function.value()(nc, color0);

--- a/src/ChromaController.cpp
+++ b/src/ChromaController.cpp
@@ -45,6 +45,7 @@ bool ChromaController::ChromaMap = false;
 bool ChromaController::TutorialMode = false;
 
 
+std::unordered_set<std::string> ChromaController::ModsForcingDoHooks = std::unordered_set<std::string>();
 
 custom_types::Helpers::Coroutine ChromaController::DelayedStartEnumerator(GlobalNamespace::BeatmapObjectSpawnController *beatmapObjectSpawnController) {
     co_yield reinterpret_cast<enumeratorT *>(CRASH_UNLESS(il2cpp_utils::New<UnityEngine::WaitForEndOfFrame *>()));
@@ -119,4 +120,13 @@ void ChromaController::SetChromaLegacy(bool v) {
 void ChromaController::setChromaRequired(bool chromaMap) {
     ChromaMap = chromaMap && getChromaConfig().customColorEventsEnabled.GetValue();
     getLogger().debug("Set chroma required/suggested to %s", ChromaMap ? "true" : "false");
+}
+
+void ChromaController::AddForceDoHooks(ModInfo& modInfo) {
+    getLogger().info("Adding force do hooks, ID: %s", modInfo.id.c_str());
+    ModsForcingDoHooks.insert(modInfo.id);
+}
+void ChromaController::RemoveForceDoHooks(ModInfo& modInfo) {
+    getLogger().info("Removing force do hooks, ID: %s", modInfo.id.c_str());
+    ModsForcingDoHooks.erase(modInfo.id);
 }

--- a/src/api/CoreAPI.cpp
+++ b/src/api/CoreAPI.cpp
@@ -1,0 +1,11 @@
+#include "CoreAPI.hpp"
+#include "ChromaController.hpp"
+
+using namespace Chroma;
+EXPOSE_API(addForceEnableChromaHooks, void, ModInfo& modInfo) {
+    ChromaController::AddForceDoHooks(modInfo);
+}
+
+EXPOSE_API(removeForceEnableChromaHooks, void, ModInfo& modInfo) {
+    ChromaController::RemoveForceDoHooks(modInfo);
+}

--- a/src/api/NoteAPI.cpp
+++ b/src/api/NoteAPI.cpp
@@ -63,6 +63,11 @@ EXPOSE_API(setNoteColorable, void, bool colorable) {
     NoteColorizer::NoteColorable = colorable;
 }
 
+EXPOSE_API(setGlobalNoteColorSafe, void, std::optional<Sombrero::FastColor> color0, std::optional<Sombrero::FastColor> color1) {
+    NoteColorizer::GlobalColorize(color0, ColorType::ColorA);
+    NoteColorizer::GlobalColorize(color1, ColorType::ColorB);
+}
+
 EXPOSE_API(isNoteColorable, bool) {
     return NoteColorizer::NoteColorable;
 }


### PR DESCRIPTION
- Fixed condep resolution of `Chroma::NoteAPI::setNoteColorSafe`
- Added API for forcing Chroma to enable its hooks, useful for mods that needs colourizers on non-chroma maps.
- Added definition for `Chroma::NoteAPI::setGlobalNoteColorSafe`.